### PR TITLE
Allow building with libc++ and C++11

### DIFF
--- a/GIZA++-v2/mystl.h
+++ b/GIZA++-v2/mystl.h
@@ -25,9 +25,13 @@ using namespace _STL;
 #include <ext/hash_map>
 using __gnu_cxx::hash_map;
 #else
+#if __cplusplus < 201103L && !defined(_LIBCPP_VERSION)
 #include <tr1/unordered_map>
-#define hash_map unordered_map
 using namespace std::tr1;
+#else
+#include <unordered_map>
+#endif
+#define hash_map unordered_map
 #endif
 
 #include <vector>

--- a/README
+++ b/README
@@ -7,7 +7,7 @@ For more information, refer to the README files and the following pages:
 
 UPDATE 4th April 2015, by Hieu Hoang:
 
-Works with most versions of gcc, including really old versions. Doesn't work with recent versions of clang.
+Works with most versions of gcc and clang, including really old versions.
 
 Why not try using mgiza? It's multi-threaded and kept up to date to work with most compilers
    https://github.com/moses-smt/mgiza

--- a/mkcls-v2/myleda.h
+++ b/mkcls-v2/myleda.h
@@ -27,7 +27,11 @@ USA.
 #define myleda_HEADER_defined
 #include <map>
 #include <set>
+#if __cplusplus < 201103L && !defined(_LIBCPP_VERSION)
 #include <tr1/unordered_map>
+#else
+#include <unordered_map>
+#endif
 #include "myassert.h"
 #include "FixedArray.h"
 using namespace std;
@@ -110,7 +114,11 @@ public:
 };
 
 inline int Hash(int value) { return value; }
+#if __cplusplus < 201103L && !defined(_LIBCPP_VERSION)
 #define MY_HASH_BASE std::tr1::unordered_map<A,B>
+#else
+#define MY_HASH_BASE unordered_map<A,B>
+#endif
 
 template<class A,class B>
 class leda_h_array : public MY_HASH_BASE

--- a/mkcls-v2/mystl.h
+++ b/mkcls-v2/mystl.h
@@ -27,13 +27,19 @@ USA.
 #define MY_STL_H_DEFINED
 #include <string>
 #include <utility>
+#if __cplusplus < 201103L && !defined(_LIBCPP_VERSION)
 #include <tr1/unordered_map>
+#else
+#include <unordered_map>
+#endif
 #include <cmath>
 
 using namespace std;
 
 namespace std {
+#if __cplusplus < 201103L && !defined(_LIBCPP_VERSION)
  namespace tr1 {
+#endif
   template <typename T, typename V>
   struct hash<pair<T, V> > {
     static inline void hash_combine(std::size_t & seed, const T & v) {
@@ -48,7 +54,9 @@ namespace std {
       return h;
     }
   };
+#if __cplusplus < 201103L && !defined(_LIBCPP_VERSION)
  }
+#endif
 }
 
 #define over_string(a,i) for(unsigned int i=0;i<a.length();i++)


### PR DESCRIPTION
Hello,

This PR fixes the problem reported in #1: that this code requires the obsolete tr1 namespace and therefore does not work with libc++ or other situations where tr1 doesn't exist.

Thanks go to @CatherineGasnier who [worked out how to build giza-pp without tr1](http://catherinegasnier.blogspot.com/2014/04/install-giza-107-on-mac-osx-1092.html). I conditionalized her approach so that compiling with old tr1 systems is still possible, but the newer alternatives will be used when compiling with libc++ or specifying C++11 mode.

I've applied this patch to [giza-pp in MacPorts](https://ports.macports.org/port/giza-pp/tickets). We were previously forcing the use of libstdc++ even on newer systems that default to libc++. This approach no longer works on the latest versions of macOS from which the libstdc++ headers have been removed.

With these changes, it compiles and displays the help message when I run the programs. I don't know anything about this software so I can't guarantee it actually works beyond that, but I assume it does.